### PR TITLE
Add property spacing rule

### DIFF
--- a/DotBlue/Sniffs/WhiteSpace/PropertySpacingSniff.php
+++ b/DotBlue/Sniffs/WhiteSpace/PropertySpacingSniff.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace DotBlue\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer_File;
+use PHP_CodeSniffer_Tokens;
+use PHP_CodeSniffer_Standards_AbstractVariableSniff;
+
+
+class PropertySpacingSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff
+{
+
+	const ALLOWED_NEXT_MODIFIER = [
+		T_PRIVATE => [T_PRIVATE, T_PROTECTED, T_PUBLIC],
+		T_PROTECTED => [T_PROTECTED, T_PUBLIC],
+		T_PUBLIC => [T_PUBLIC],
+	];
+
+
+
+	protected function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$modifier = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$scopeModifiers, $stackPtr);
+
+		if ($modifier && ($tokens[$modifier]['line'] === $tokens[$stackPtr]['line'])) {
+			// ignore static for now
+			$isStatic = $phpcsFile->findNext(T_STATIC, $modifier + 1, $stackPtr);
+			if ($isStatic) {
+				return;
+			}
+
+			// find next declaration or docblock
+			$next = $phpcsFile->findNext(array_merge(
+				[T_DOC_COMMENT_OPEN_TAG],
+				PHP_CodeSniffer_Tokens::$scopeModifiers
+			), ($stackPtr + 1));
+			$semicolon = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
+			if ($next) {
+				$diff = abs($tokens[$next]['line'] - $tokens[$semicolon]['line']);
+				$function = $phpcsFile->findNext(T_FUNCTION, $next + 1);
+				// if there is no variable between whatever we
+				// found and the function, this is the last
+				// variable and there should be three spaces
+				$variable = $phpcsFile->findNext(T_VARIABLE, $next + 1, $function);
+				if ($variable) {
+					// we want three spaces between different
+					// visibility levels, otherwise two
+					$expected = 3;
+					$nextModifier = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$scopeModifiers, ($stackPtr + 1), $variable);
+					if ($nextModifier) {
+						$thisCode = $tokens[$modifier]['code'];
+						$nextCode = $tokens[$nextModifier]['code'];
+						if ($thisCode !== $nextCode && !in_array($nextCode, self::ALLOWED_NEXT_MODIFIER[$thisCode])) {
+							$phpcsFile->addError("Property visibility must be ordered from private to protected to public, found %s, next is %s", $stackPtr, 'VisibilityOrder', [token_name($thisCode), token_name($nextCode)]);
+							return;
+						}
+					}
+					if ($tokens[$modifier]['code'] !== $tokens[$nextModifier]['code']) {
+						$expected = 4;
+					}
+					if ($diff !== $expected) {
+						$phpcsFile->addError("Must have %d spaces between properties%s, found %d", $stackPtr, 'EmptyLines', [
+							$expected - 1,
+							($expected === 4 ? " with different visibility scopes" : ""),
+							$diff - 1,
+						]);
+					}
+				} elseif ($diff !== 4) {
+					$phpcsFile->addError("Must have 3 spaces between last property and first function, found %d", $stackPtr, 'EmptyLines', [$diff - 1]);
+				}
+			}
+		}
+	}
+
+
+
+	protected function processVariable(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	{
+		/* We don't care about normal variables. */
+	}
+
+
+
+	protected function processVariableInString(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	{
+		/* We don't care about normal variables. */
+	}
+
+}

--- a/DotBlue/tests/PropertySpacingSniff.phpt
+++ b/DotBlue/tests/PropertySpacingSniff.phpt
@@ -1,0 +1,31 @@
+<?php
+
+use DotBlue\CodeSniffer\Helpers\Tester;
+
+
+require __DIR__ . '/bootstrap.php';
+
+$tester = new Tester();
+$tester->setFile('PropertySpacing_1')
+    ->setSniff('WhiteSpace.PropertySpacing')
+    ->expectMessage('Must have 3 spaces between properties with different visibility scopes, found 2')
+    ->onLine(9)
+    ->getFile()
+    ->expectMessage('Must have 3 spaces between properties with different visibility scopes, found 1')
+    ->onLine(12);
+
+$tester->setFile('PropertySpacing_2')
+    ->setSniff('WhiteSpace.PropertySpacing')
+    ->expectMessage('Must have 2 spaces between properties, found 1')
+    ->onLine(9);
+
+$tester->setFile('PropertySpacing_3')
+    ->setSniff('WhiteSpace.PropertySpacing')
+    ->expectMessage('Property visibility must be ordered from private to protected to public, found T_PUBLIC, next is T_PROTECTED')
+    ->onLine(6)
+    ->getFile()
+    ->expectMessage('Property visibility must be ordered from private to protected to public, found T_PROTECTED, next is T_PRIVATE')
+    ->onLine(10);
+
+
+$tester->test();

--- a/DotBlue/tests/invalid/PropertySpacing_1.php
+++ b/DotBlue/tests/invalid/PropertySpacing_1.php
@@ -1,0 +1,20 @@
+<?php
+
+class Foo
+{
+
+    private $a;
+
+
+    private $b;
+
+
+    protected $c;
+
+    public $d;
+
+
+
+    public function __construct() { }
+
+}

--- a/DotBlue/tests/invalid/PropertySpacing_2.php
+++ b/DotBlue/tests/invalid/PropertySpacing_2.php
@@ -1,0 +1,20 @@
+<?php
+
+class Foo
+{
+
+    private $a;
+
+
+    private $b;
+
+    /**
+     * @var string
+     */
+    private $c;
+
+
+
+    public function __construct() { }
+
+}

--- a/DotBlue/tests/invalid/PropertySpacing_3.php
+++ b/DotBlue/tests/invalid/PropertySpacing_3.php
@@ -1,0 +1,24 @@
+<?php
+
+class Foo
+{
+
+    public $a;
+
+
+
+    protected $b;
+
+
+
+    private $c;
+
+
+
+    protected $d;
+
+
+
+    public function __construct() { }
+
+}

--- a/DotBlue/tests/php.ini
+++ b/DotBlue/tests/php.ini
@@ -1,0 +1,2 @@
+extension=simplexml.so
+extension=tokenizer.so

--- a/DotBlue/tests/valid/PropertySpacing_1.php
+++ b/DotBlue/tests/valid/PropertySpacing_1.php
@@ -1,0 +1,23 @@
+<?php
+
+class Foo
+{
+
+    private $a;
+
+
+    private $b;
+
+
+
+    protected $c;
+
+
+
+    public $d;
+
+
+
+    public function __construct() { }
+
+}

--- a/DotBlue/tests/valid/PropertySpacing_2.php
+++ b/DotBlue/tests/valid/PropertySpacing_2.php
@@ -1,0 +1,21 @@
+<?php
+
+class Foo
+{
+
+    private $a;
+
+
+    private $b;
+
+
+    /**
+     * @var string
+     */
+    private $c;
+
+
+
+    public function __construct() { }
+
+}

--- a/DotBlue/tests/valid/PropertySpacing_3.php
+++ b/DotBlue/tests/valid/PropertySpacing_3.php
@@ -1,0 +1,23 @@
+<?php
+
+class Foo
+{
+
+    private $a;
+
+
+
+    protected $b;
+
+
+    protected $d;
+
+
+
+    public $c;
+
+
+
+    public function __construct() { }
+
+}


### PR DESCRIPTION
Currently, the following is implemented:

* Check that the order is private, protected, public
* There must be two spaces between same visibitlity properties
* There must be three spaces between different visibility properties
* There must be three spaces after the last property and before the first function