### PR TITLE
Make a universal SalesChamp style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{js,hbs,less,es6,php,phpt,handlebars}]
+indent_style = tab
+indent_size = 4
+
+[*.{neon}]
+indent_style = space
+indent_size = 4
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[{.bowerrc,package.json}]
+indent_style = space
+indent_size = 2

--- a/DotBlue/Sniffs/Namespaces/UseDeclarationSniff.php
+++ b/DotBlue/Sniffs/Namespaces/UseDeclarationSniff.php
@@ -110,7 +110,6 @@ class UseDeclarationSniff extends PSR2_Sniffs_Namespaces_UseDeclarationSniff
 		}
 
 		return FALSE;
-
 	}
 
 }

--- a/DotBlue/Sniffs/PhpDoc/MethodParametersSniff.php
+++ b/DotBlue/Sniffs/PhpDoc/MethodParametersSniff.php
@@ -29,7 +29,6 @@ class MethodParametersSniff implements PHP_CodeSniffer_Sniff
 		if ($tokens[$stackPtr]['content'] === '@return') {
 			$this->processReturn($phpcsFile, $stackPtr, $tokens);
 		}
-
 	}
 
 

--- a/DotBlue/Sniffs/Scope/MethodScopeSniff.php
+++ b/DotBlue/Sniffs/Scope/MethodScopeSniff.php
@@ -54,7 +54,6 @@ class MethodScopeSniff extends Squiz_Sniffs_Scope_MethodScopeSniff
 				$phpcsFile->fixer->endChangeset();
 			}
 		}
-
 	}
 
 

--- a/DotBlue/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/DotBlue/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -184,7 +184,6 @@ class FunctionSpacingSniff extends Squiz_Sniffs_WhiteSpace_FunctionSpacingSniff
 				}
 			}
 		}
-
 	}
 
 }

--- a/DotBlue/tests/helpers/Tester.php
+++ b/DotBlue/tests/helpers/Tester.php
@@ -53,7 +53,7 @@ class Tester
 			}
 			$sniffer->registerSniffs([
 				Tester::$setup['sniffsDir'] . '/' . str_replace('.', '/', $testedFile->getSniff()) . 'Sniff.php',
-			], []);
+			], [], []);
 			$sniffer->populateTokenListeners();
 			$testedFile->evaluate($sniffer);
 		}

--- a/DotBlue/tests/valid/FunctionSpacing.php
+++ b/DotBlue/tests/valid/FunctionSpacing.php
@@ -8,14 +8,12 @@ class Bar
 
 	public function foo()
 	{
-
 	}
 
 
 
 	public function bar()
 	{
-
 	}
 
 }

--- a/SalesChamp/ruleset.xml
+++ b/SalesChamp/ruleset.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+
+<ruleset name="DotBlue">
+
+    <description>SalesChamp coding standard</description>
+    <arg name="tab-width" value="4"/>
+
+    <rule ref="./../DotBlue/ruleset.xml">
+        <!-- We require doc blocks to include property names if applicable -->
+        <exclude name="DotBlue.PhpDoc.MethodParameters"/>
+        <exclude name="Generic.PHP.UpperCaseConstant"/>
+        <!-- We don't want to enforce bool over boolean -->
+        <exclude name="DotBlue.Conventions.BoolNaming"/>
+        <!-- Sometimes it makes sense to provide default values for parameters that are not at the end of argument list -->
+        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd"/>
+        <!-- require statements in tests -->
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+        <!-- Use SlevomatCodingStandard.Classes.UnusedPrivateElements instead -->
+        <exclude name="DotBlue.Php.UnusedPrivateProperties" />
+    </rule>
+
+    <rule ref="./../../../slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Namespaces/UnusedUsesSniff.php" />
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+      <properties>
+        <property name="searchAnnotations" value="true" />
+      </properties>
+    </rule>
+
+    <rule ref="./../../../slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php" />
+
+    <rule ref="./../../../wimg/php-compatibility/PHPCompatibility/ruleset.xml" />
+
+    <rule ref="Squiz.Arrays.ArrayDeclaration">
+        <!-- due to tab indent -->
+        <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
+    </rule>
+
+    <rule ref="Squiz.Strings.DoubleQuoteUsage">
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
+    </rule>
+
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
+
+    <arg name="encoding" value="utf8"/>
+    <arg name="extensions" value="php,phpt"/>
+
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,14 @@
 {
-  "name": "dotblue/codesniffer-ruleset",
-  "require-dev": {
-    "nette/tester": "~1.3",
-    "squizlabs/php_codesniffer": "~2.5.0"
-  },
-  "autoload-dev": {
-    "classmap": ["DotBlue/tests/helpers"]
-  }
+    "name": "dotblue/codesniffer-ruleset",
+    "require": {
+        "squizlabs/php_codesniffer": "^2.9.0",
+        "slevomat/coding-standard": "^2.4",
+        "wimg/php-compatibility": "^8.0"
+    },
+    "require-dev": {
+        "nette/tester": "~1.3"
+    },
+    "autoload-dev": {
+        "classmap": ["DotBlue/tests/helpers"]
+    }
 }


### PR DESCRIPTION
To install into a project, use

```xml
<?xml version="1.0"?>
<ruleset name="SalesChamp">

    <rule ref="./vendor/dotblue/codesniffer-ruleset/SalesChamp/ruleset.xml" />

    <file>./app</file>
    <file>./libs</file>
    <file>./tests/php</file>
    <file>./www</file>

</ruleset>
```

where the `file` elements specify the directories of the current project where to enforce the rules.  There should be nothing else in the file and the general rules should go to this package instead.

The only composer dependency should be `"dotblue/codesniffer-ruleset": "^1.0"` which will pull all other rulesets as well as a compatible codesniffer.