### PR TITLE
Do not require all keys to be specified in mixed arrays

### DIFF
--- a/SalesChamp/ruleset.xml
+++ b/SalesChamp/ruleset.xml
@@ -38,6 +38,7 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
         <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
         <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.KeySpecified"/>
     </rule>
 
     <rule ref="Squiz.Strings.DoubleQuoteUsage">

--- a/SalesChamp/ruleset.xml
+++ b/SalesChamp/ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<ruleset name="DotBlue">
+<ruleset name="SalesChamp">
 
     <description>SalesChamp coding standard</description>
     <arg name="tab-width" value="4"/>


### PR DESCRIPTION
This allows us to have an array such as:

```php
[
    'a',
    'key' => 'b',
]
```

otherwise, 'a' would require explicit key `0 =>`